### PR TITLE
Add arm32 Debian configuration

### DIFF
--- a/configs/debian/debian_server_arm32.yaml
+++ b/configs/debian/debian_server_arm32.yaml
@@ -1,0 +1,117 @@
+# Copyright 2022-2024 NXP
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Shengzhou Liu <shengzhou.liu@nxp.com>
+#
+# Customized Debian server rootfs for NXP i.MX & Layerscape MPU platforms
+
+
+---
+mmdebstrap:
+  architectures:
+    - arm32
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: bookworm
+  target: rootfs
+  hostname: localhost
+  variant: standard
+  components:
+    - main
+    - contrib
+  packages:
+    - init
+    - udev
+    - sudo
+    - vim
+    - apt
+    - file
+    - zstd
+    - parted
+    - fdisk
+    - dosfstools
+    - iputils-ping
+    - isc-dhcp-client
+    - memtool
+    - wget
+    - curl
+    - ca-certificates
+    - systemd
+    - systemd-sysv
+    - psmisc   # for fuser, killall, etc
+    - ethtool
+    - net-tools
+    - iproute2
+    - openssh-server
+    - openssh-client
+    - patchelf
+    - htop
+    - cpuinfo
+    - util-linux
+    - lshw
+    - keyutils
+    - wpasupplicant
+    - ntpdate
+    - bridge-utils
+    - tcpdump
+    - mtd-utils
+    - pciutils
+    - hdparm psmisc
+    - libssl-dev
+    - usbutils # for lsusb
+    - sysstat
+    - lsb-release
+    - kexec-tools
+    - iptables
+    - libhugetlbfs0
+    - strongswan
+    - libcharon-extra-plugins
+    - dmidecode
+    - flex
+    - rdate
+    - initramfs-tools
+    - fbset
+    - mmc-utils
+    - usbutils
+    - i2c-tools
+    - lm-sensors
+    - rt-tests
+    - linuxptp
+    - mosquitto
+  setup-hooks:
+      # Setup NXP board-specific configurations for various platforms
+    - 'mkdir -p $1/usr/local/bin'
+    - 'mkdir -p $1/etc/systemd/system/multi-user.target.wants'
+    - 'mkdir -p $1/etc/systemd/system/local-fs.target.wants'
+  essential-hooks:
+    - 'sleep 10'
+  customize-hooks:
+    - 'chroot "$1" useradd -m -d /home/debian -s /bin/bash debian'
+    - 'chroot "$1" gpasswd -a debian sudo'
+    - 'chroot "$1" usermod -aG sudo debian'
+    - 'chroot "$1" passwd --delete root'
+    - 'chroot "$1" passwd --delete debian'
+    - 'chroot "$1" apt-get update'
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+    - 'cp src/misc/boot.mount $1/lib/systemd/system/'
+    - 'cp tools/flex-installer $1/usr/bin/'
+    - 'cp tools/resizerfs $1/usr/bin/'
+    - 'cp src/misc/udev/udev-rules-*/*.rules $1/etc/udev/rules.d/'
+    - 'cp src/misc/debian/distroplatcfg $1/usr/bin/'
+    - 'cp src/misc/debian/platcfg.service $1/lib/systemd/system/'
+    - 'chroot "$1" ln -s /lib/systemd/system/platcfg.service /etc/systemd/system/multi-user.target.wants/platcfg.service'
+    - 'chroot "$1" ln -s /lib/systemd/system/boot.mount /etc/systemd/system/local-fs.target.wants/boot.mount'
+    - 'chroot "$1" ln -s /boot/tools/perf /usr/local/bin/perf'
+    - 'chroot "$1" ln -s /sbin/init /init'
+    - 'chroot "$1" ln -s /boot/modules /lib/modules'
+    - 'chroot "$1" rm -rf /lib/firmware'
+    - 'chroot "$1" ln -s /boot/firmware /lib/firmware'
+    - 'printf "/usr/lib\n" >> $1/etc/ld.so.conf.d/01-sdk.conf'
+    - 'printf " * Support:   https://www.nxp.com/support\n" >> $1/etc/update-motd.d/20-help-text'
+    - 'printf " * Licensing: https://lsdk.github.io/eula\n" >> $1/etc/update-motd.d/20-help-text'
+    - 'printf "NXP LSDK 2406 Debian Server (optimized with NXP-specific hardware acceleration)\n" >> $1/etc/issue'
+    - 'printf "Build: `date --rfc-3339 seconds`\n" >> $1/etc/buildinfo'


### PR DESCRIPTION
Related to #4

Add a new configuration file `debian_server_arm32.yaml` for arm32 builds.

* Create `configs/debian/debian_server_arm32.yaml` with appropriate configurations for arm32 builds.
* Copy content from `debian_server_arm64.yaml` and update the architecture to `arm32`.
* Include necessary packages and setup hooks for arm32 builds.
* Add essential and customize hooks for setting up the Debian server root filesystem for arm32.

