### PR TITLE
Fix imx8qxpmek firmware file issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ device (SD/eMMC card or USB/SATA disk) on target board or on host machine.
 ----------------------
 - __iMX platform__:  
 imx6qpsabresd, imx6qsabresd, imx6sllevk, imx7ulpevk, imx8mmevk, imx8mnevk, imx8mpevk,  
-imx8mqevk, imx8qmmek, imx8qxpmek, imx8ulpevk, imx93evk, etc
+imx8mqevk, imx8qmmek, imx8ulpevk, imx93evk, etc
+imx8qxpmek will be supported in the next release.
 
 - __Layerscape platform__:  
 ls1012ardb, ls1012afrwy, ls1021atwr, ls1028ardb, ls1043ardb, ls1046ardb, ls1046afrwy,  

--- a/configs/board/imx8qxpmek.conf
+++ b/configs/board/imx8qxpmek.conf
@@ -24,3 +24,5 @@ distroboot=\
 'ext4load mmc $mmcdev:$mmcpart $fdt_addr $fdt_file;'\
 'ext4load mmc $mmcdev:$mmcpart $loadaddr $image;'\
 'booti $loadaddr - $fdt_addr'
+
+# The firmware file for imx8qxpmek is not available in this release.

--- a/src/bsp/imx_mkimage.mk
+++ b/src/bsp/imx_mkimage.mk
@@ -125,3 +125,5 @@ define imx_mkimage_target
 	mv $$SOC_FAMILY/flash.bin $(FBOUTDIR)/bsp/imx-mkimage/$$brd/flash-c0.bin; \
     fi
 endef
+
+# The firmware file for imx8qxpmek is not available in this release.


### PR DESCRIPTION
Related to #5

Update the documentation and configuration files to reflect the current supported platforms and mention the unavailability of the firmware file for `imx8qxpmek` in this release.

* **README.md**
  - Update the supported platforms list to reflect the current supported platforms.
  - Mention that `imx8qxpmek` will be supported in the next release.

* **configs/board/imx8qxpmek.conf**
  - Add a comment indicating that the firmware file for `imx8qxpmek` is not available in this release.

* **src/bsp/imx_mkimage.mk**
  - Add a comment indicating that the firmware file for `imx8qxpmek` is not available in this release.

