### PR TITLE
Add board configuration for Phygate Tauri L (IMX8M Mini)

### DIFF
--- a/configs/board/imx8mm_phygate-tauri-l.conf
+++ b/configs/board/imx8mm_phygate-tauri-l.conf
@@ -1,0 +1,30 @@
+# [general]
+
+machine=imx8mm_phygate-tauri-l
+
+# Use PHYTEC U-Boot defconfig for i.MX8MM phyBOARD-Polis
+UBOOT_CONFIG="phycore-imx8mm_defconfig"
+
+# Composite firmware image (flash.bin) produced by imx-mkimage
+COMPOSITE_IMG1_FILE_sd="bsp/imx-mkimage/imx8mm_phygate-tauri-l/flash.bin"
+
+# Offset for bootloader on SD (33 KiB)
+DISK_BOOTLOADER_OFFSET="33792"
+
+# Distro boot script output path
+distro_bootscript="bsp/u-boot/imx8mm_phygate-tauri-l/imx8mm_phygate-tauri-l_boot.scr"
+
+# Default distro boot sequence
+# Notes:
+# - fdtfile default points to PHYTEC Polis DTB; override in U-Boot env if needed
+# - console defaults to ttymxc1 (common on i.MX9MM); adjust if your board uses a different UART
+distroboot=\
+'env exists fdtfile || setenv fdtfile imx8mm-phyboard-polis-rdk.dtb;'\
+'env exists image || setenv image Image;'\
+'env exists devpart_boot || setenv devpart_boot 1;'\
+'env exists devpart_root || setenv devpart_root 3;'\
+'part uuid $devtype $devnum:$devpart_root partuuidr;'\
+'setenv bootargs console=ttymxc1,115200 root=PARTUUID=$partuuidr rw rootwait $othbootargs;'\
+'ext4load mmc $mmcdev:$devpart_boot $fdt_addr $fdtfile;'\
+'ext4load mmc $mmcdev:$devpart_boot $loadaddr $image;'\
+'booti $loadaddr - $fdt_addr'


### PR DESCRIPTION
Added configuration file for Phygate Tauri L (i.MX8M Mini) board.
Includes U-Boot defconfig, composite firmware image path, bootloader offset, and default distro boot sequence for SD card boot.